### PR TITLE
refactor: moved `HttpResponse` to its own file to signify its importance

### DIFF
--- a/src/main/java/com/github/flo456123/BackBond/entry/update/DataUpdater.java
+++ b/src/main/java/com/github/flo456123/BackBond/entry/update/DataUpdater.java
@@ -63,7 +63,7 @@ public class DataUpdater {
         try (HttpClientWrapper httpClientWrapper = new HttpClientWrapper()) {
             for (int year = yearRangeStart; year <= yearRangeEnd; year++) {
                 // fetch XML data from the httpClientWrapper
-                HttpClientWrapper.HttpResponse response = httpClientWrapper.fetchXmlData(baseUrl + year);
+                HttpResponse response = httpClientWrapper.fetchXmlData(baseUrl + year);
 
                 try (InputStream inputStream = response.inputStream()) {
                     // parse the XML data using xmlParser

--- a/src/main/java/com/github/flo456123/BackBond/entry/update/HttpClientWrapper.java
+++ b/src/main/java/com/github/flo456123/BackBond/entry/update/HttpClientWrapper.java
@@ -68,17 +68,4 @@ public class HttpClientWrapper implements Closeable {
         httpClient.close();
         connectionManager.close();
     }
-
-    /**
-     * Wrapper around the {@link InputStream} class to reduce verbosity.
-     *
-     * @param inputStream the input stream containing the XML data
-     */
-    public record HttpResponse(InputStream inputStream) implements Closeable {
-
-        @Override
-        public void close() throws IOException {
-            inputStream.close();
-        }
-    }
 }

--- a/src/main/java/com/github/flo456123/BackBond/entry/update/HttpResponse.java
+++ b/src/main/java/com/github/flo456123/BackBond/entry/update/HttpResponse.java
@@ -1,0 +1,18 @@
+package com.github.flo456123.BackBond.entry.update;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Wrapper around the {@link InputStream} class to reduce verbosity.
+ *
+ * @param inputStream the input stream containing the XML data
+ */
+public record HttpResponse(InputStream inputStream) implements Closeable {
+
+    @Override
+    public void close() throws IOException {
+        inputStream.close();
+    }
+}


### PR DESCRIPTION
Simple refactor which moved the `HttpResponse` record into its own class. I also switched from using a list to a queue in a previous commit, but I can't remember which one so it's whatever.

closes #8 