### PR TITLE
Pycr Refactors - `LocalDateTime`

### DIFF
--- a/src/main/java/com/github/flo456123/BackBond/BackBondApplication.java
+++ b/src/main/java/com/github/flo456123/BackBond/BackBondApplication.java
@@ -7,9 +7,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @SpringBootApplication
 @EnableScheduling
 public class BackBondApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(BackBondApplication.class, args);
 	}
-
 }

--- a/src/main/java/com/github/flo456123/BackBond/entry/Entry.java
+++ b/src/main/java/com/github/flo456123/BackBond/entry/Entry.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Data
 @Builder
@@ -23,7 +23,7 @@ public class Entry {
     @GeneratedValue
     private Integer id;
 
-    private LocalDateTime newDate;
+    private LocalDate newDate;
 
     private double BC_1MONTH;
     private double BC_2MONTH;

--- a/src/main/java/com/github/flo456123/BackBond/entry/EntryProjection.java
+++ b/src/main/java/com/github/flo456123/BackBond/entry/EntryProjection.java
@@ -1,12 +1,12 @@
 package com.github.flo456123.BackBond.entry;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 /**
  * Interface for encapsulating the single {@link Entry}
  * data properties.
  */
 public interface EntryProjection {
-    LocalDateTime getDate();
+    LocalDate getDate();
     double getValue();
 }

--- a/src/main/java/com/github/flo456123/BackBond/entry/EntryProjectionImpl.java
+++ b/src/main/java/com/github/flo456123/BackBond/entry/EntryProjectionImpl.java
@@ -1,23 +1,23 @@
 package com.github.flo456123.BackBond.entry;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 /**
  * Implementation of {@link EntryProjection} which defines
  * a constructor and two fields for storing value and date.
  */
 public class EntryProjectionImpl implements EntryProjection {
-    private LocalDateTime date;
-    private double value;
+    private final LocalDate date;
+    private final double value;
 
-    public EntryProjectionImpl(LocalDateTime date, double value) {
+    public EntryProjectionImpl(LocalDate date, double value) {
         this.date = date;
         this.value = value;
     }
 
     // implement methods from the EntryProjection interface
     @Override
-    public LocalDateTime getDate() {
+    public LocalDate getDate() {
         return date;
     }
 

--- a/src/main/java/com/github/flo456123/BackBond/entry/PYCRController.java
+++ b/src/main/java/com/github/flo456123/BackBond/entry/PYCRController.java
@@ -5,7 +5,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -51,8 +51,8 @@ public class PYCRController {
      */
     @GetMapping("/entries")
     public ResponseEntity<List<Entry>> getEntries(
-            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime startDate,
-            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime endDate
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate
     ) {
         List<Entry> entries;
 
@@ -79,8 +79,8 @@ public class PYCRController {
     @GetMapping("/entries/{col}")
     public ResponseEntity<List<EntryProjectionImpl>> getColumn(
             @PathVariable() String col,
-            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime startDate,
-            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime endDate
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+            @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate
     ) {
         List<EntryProjectionImpl> entries;
 

--- a/src/main/java/com/github/flo456123/BackBond/entry/PYCRRepository.java
+++ b/src/main/java/com/github/flo456123/BackBond/entry/PYCRRepository.java
@@ -3,14 +3,14 @@ package com.github.flo456123.BackBond.entry;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 public interface PYCRRepository
         extends JpaRepository<Entry, Integer> {
 
     @Query("SELECT e FROM Entry e WHERE e.newDate BETWEEN ?1 AND ?2")
-    List<Entry> findEntriesByDateRange(LocalDateTime startDate, LocalDateTime endDate);
+    List<Entry> findEntriesByDateRange(LocalDate startDate, LocalDate endDate);
 
     /**
      * Only used by update service to check if entries are
@@ -19,5 +19,5 @@ public interface PYCRRepository
      * @return a list of all the dates
      */
     @Query("SELECT newDate FROM Entry")
-    List<LocalDateTime> findAllDates();
+    List<LocalDate> findAllDates();
 }

--- a/src/main/java/com/github/flo456123/BackBond/entry/PYCRService.java
+++ b/src/main/java/com/github/flo456123/BackBond/entry/PYCRService.java
@@ -7,7 +7,7 @@ import jakarta.persistence.criteria.Root;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Queue;
 
@@ -27,7 +27,7 @@ public class PYCRService {
     }
 
     public void addNewEntries(Queue<Entry> entries) {
-        List<LocalDateTime> existingDates = entryRepository.findAllDates();
+        List<LocalDate> existingDates = entryRepository.findAllDates();
 
         List<Entry> newEntries = entries.stream()
                 .filter(entry -> !existingDates.contains(entry.getNewDate()))
@@ -50,7 +50,7 @@ public class PYCRService {
         return entityManager.createQuery(query).getResultList();
     }
 
-    public List<Entry> getForDateRange(LocalDateTime startDate, LocalDateTime endDate) {
+    public List<Entry> getForDateRange(LocalDate startDate, LocalDate endDate) {
         if (startDate.isAfter(endDate)) {
             throw new IllegalArgumentException("start date cannot be after end date");
         }
@@ -58,7 +58,7 @@ public class PYCRService {
         return entryRepository.findEntriesByDateRange(startDate, endDate);
     }
 
-    public List<EntryProjectionImpl> getColumnForDateRange(String col, LocalDateTime startDate, LocalDateTime endDate) {
+    public List<EntryProjectionImpl> getColumnForDateRange(String col, LocalDate startDate, LocalDate endDate) {
         if (col.isEmpty()) {
             throw new IllegalArgumentException("column name cannot be empty");
         }

--- a/src/main/java/com/github/flo456123/BackBond/entry/update/XmlParser.java
+++ b/src/main/java/com/github/flo456123/BackBond/entry/update/XmlParser.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
+import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
@@ -16,7 +17,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.LinkedList;
 import java.util.Queue;
 
@@ -66,7 +67,7 @@ public class XmlParser {
     private Entry parseEntryElement(Element entryElement)
     {
         Entry entry = new Entry();
-        entry.setNewDate(LocalDateTime.parse(entryElement.getElementsByTagName("d:NEW_DATE").item(0).getTextContent()));
+        entry.setNewDate(parseElementDate(entryElement));
 
         Field[] fields = Entry.class.getDeclaredFields();
         // iterate through each field of the Entry class, and set it to the double value
@@ -86,6 +87,19 @@ public class XmlParser {
         }
 
         return entry;
+    }
+
+    /**
+     * Parses an element into the ISO-8601 calendar system
+     * format.
+     *
+     * @param element The element to parse.
+     * @return A {@link LocalDate} instance of the date.
+     */
+    private LocalDate parseElementDate(Element element) {
+        Node node = element.getElementsByTagName("d:NEW_DATE").item(0);
+        String splitContent = node.getTextContent().split("T")[0];
+        return LocalDate.parse(splitContent);
     }
 
     final double DEFAULT_VALUE = 0.0;


### PR DESCRIPTION
Refactored the application to work with `LocalDate` instead of `LocalDateTime` because literally every entry had the time of "00:00:00."

Hopefully this will improve storage space taken by each date as well as processing entries on the frontend.

Closes #11 