### PR TITLE
Capture Queries

### DIFF
--- a/src/main/java/com/github/flo456123/BackBond/api/PYCRController.java
+++ b/src/main/java/com/github/flo456123/BackBond/api/PYCRController.java
@@ -58,8 +58,11 @@ public class PYCRController {
 
         if (startDate != null && endDate != null) {
             entries = entryService.getForDateRange(startDate, endDate);
-        }
-        else {
+        } else if (startDate != null) {
+            entries = entryService.getForDateRange(startDate, LocalDate.now());
+        } else if (endDate != null) {
+            entries = entryService.getForDateRange(LocalDate.now(), endDate);
+        } else {
             entries = entryService.getEntries();
         }
 
@@ -77,18 +80,21 @@ public class PYCRController {
      * @return a list containing the interest rate data for a column
      */
     @GetMapping("/entries/{col}")
-    public ResponseEntity<List<EntryProjectionImpl>> getColumn(
+    public ResponseEntity<List<EntryProjection>> getColumn(
             @PathVariable() String col,
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate
     ) {
-        List<EntryProjectionImpl> entries;
+        List<EntryProjection> entries;
 
         if (startDate != null && endDate != null) {
             entries = entryService.getColumnForDateRange(col, startDate, endDate);
-        }
-        else {
-             entries = entryService.getColumn(col);
+        } else if (startDate != null) {
+            entries = entryService.getColumnForDateRange(col, startDate, LocalDate.now());
+        } else if (endDate != null) {
+            entries = entryService.getColumnForDateRange(col, LocalDate.now(), endDate);
+        } else {
+            entries = entryService.getColumn(col);
         }
 
         return ResponseEntity.ok(entries);

--- a/src/main/java/com/github/flo456123/BackBond/api/PYCRController.java
+++ b/src/main/java/com/github/flo456123/BackBond/api/PYCRController.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
 
 /**
  * A {@link RestController} to handle incoming HTTP requests under the ``/BackBond/api/v1`` request mapping.
@@ -54,17 +56,10 @@ public class PYCRController {
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate
     ) {
-        List<Entry> entries;
-
-        if (startDate != null && endDate != null) {
-            entries = entryService.getForDateRange(startDate, endDate);
-        } else if (startDate != null) {
-            entries = entryService.getForDateRange(startDate, LocalDate.now());
-        } else if (endDate != null) {
-            entries = entryService.getForDateRange(LocalDate.of(1990, 1, 2), endDate);
-        } else {
-            entries = entryService.getEntries();
-        }
+        List<Entry> entries = handleDateRangeQuery(startDate, endDate,
+                entryService::getEntries,
+                entryService::getForDateRange
+        );
 
         return ResponseEntity.ok(entries);
     }
@@ -85,18 +80,35 @@ public class PYCRController {
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
             @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate
     ) {
-        List<EntryProjection> entries;
-
-        if (startDate != null && endDate != null) {
-            entries = entryService.getColumnForDateRange(col, startDate, endDate);
-        } else if (startDate != null) {
-            entries = entryService.getColumnForDateRange(col, startDate, LocalDate.now());
-        } else if (endDate != null) {
-            entries = entryService.getColumnForDateRange(col, LocalDate.of(1990, 1, 2), endDate);
-        } else {
-            entries = entryService.getColumn(col);
-        }
+        List<EntryProjection> entries = handleDateRangeQuery(startDate, endDate,
+                () -> entryService.getColumn(col),
+                (sDate, eDate) -> entryService.getColumnForDateRange(col, sDate, eDate)
+        );
 
         return ResponseEntity.ok(entries);
     }
+
+    /**
+     * This helper function is used to avoid breaking the "don't repeat yourself" (DRY)
+     * coding principle by having the client supplying an operation and solely applying
+     * them depending on if the start and end dates are present.
+     *
+     * @param noDateRangeSupplier the function to call if there is no date present
+     * @param dateRangeSupplier the function to call if there is a date range present
+     * @return the resulting query
+     */
+    private <T> List<T> handleDateRangeQuery(LocalDate startDate, LocalDate endDate,
+                                             Supplier<List<T>> noDateRangeSupplier,
+                                             BiFunction<LocalDate, LocalDate, List<T>> dateRangeSupplier) {
+        if (startDate != null && endDate != null) {
+            return dateRangeSupplier.apply(startDate, endDate);
+        } else if (startDate != null) {
+            return dateRangeSupplier.apply(startDate, LocalDate.now());
+        } else if (endDate != null) {
+            return dateRangeSupplier.apply(LocalDate.of(1990, 1, 2), endDate);
+        } else {
+            return noDateRangeSupplier.get();
+        }
+    }
+
 }

--- a/src/main/java/com/github/flo456123/BackBond/api/PYCRController.java
+++ b/src/main/java/com/github/flo456123/BackBond/api/PYCRController.java
@@ -61,7 +61,7 @@ public class PYCRController {
         } else if (startDate != null) {
             entries = entryService.getForDateRange(startDate, LocalDate.now());
         } else if (endDate != null) {
-            entries = entryService.getForDateRange(LocalDate.now(), endDate);
+            entries = entryService.getForDateRange(LocalDate.of(1990, 1, 2), endDate);
         } else {
             entries = entryService.getEntries();
         }
@@ -92,7 +92,7 @@ public class PYCRController {
         } else if (startDate != null) {
             entries = entryService.getColumnForDateRange(col, startDate, LocalDate.now());
         } else if (endDate != null) {
-            entries = entryService.getColumnForDateRange(col, LocalDate.now(), endDate);
+            entries = entryService.getColumnForDateRange(col, LocalDate.of(1990, 1, 2), endDate);
         } else {
             entries = entryService.getColumn(col);
         }

--- a/src/main/java/com/github/flo456123/BackBond/api/PYCRService.java
+++ b/src/main/java/com/github/flo456123/BackBond/api/PYCRService.java
@@ -36,13 +36,13 @@ public class PYCRService {
         entryRepository.saveAll(newEntries);
     }
 
-    public List<EntryProjectionImpl> getColumn(String col) {
+    public List<EntryProjection> getColumn(String col) {
         if (col.isEmpty()) {
             throw new IllegalArgumentException("column name cannot be empty");
         }
 
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-        CriteriaQuery<EntryProjectionImpl> query = cb.createQuery(EntryProjectionImpl.class);
+        CriteriaQuery<EntryProjection> query = cb.createQuery(EntryProjection.class);
         Root<Entry> root = query.from(Entry.class);
 
         query.select(cb.construct(EntryProjectionImpl.class, root.get("newDate"), root.get(col)));
@@ -58,17 +58,17 @@ public class PYCRService {
         return entryRepository.findEntriesByDateRange(startDate, endDate);
     }
 
-    public List<EntryProjectionImpl> getColumnForDateRange(String col, LocalDate startDate, LocalDate endDate) {
+    public List<EntryProjection> getColumnForDateRange(String col, LocalDate startDate, LocalDate endDate) {
         if (col.isEmpty()) {
             throw new IllegalArgumentException("column name cannot be empty");
         }
 
         CriteriaBuilder cb = entityManager.getCriteriaBuilder();
-        CriteriaQuery<EntryProjectionImpl> query = cb.createQuery(EntryProjectionImpl.class);
+        CriteriaQuery<EntryProjection> query = cb.createQuery(EntryProjection.class);
         Root<Entry> root = query.from(Entry.class);
 
         query.select(cb.construct(EntryProjectionImpl.class, root.get("newDate"), root.get(col)))
-                .where(cb.between(root.get("newDate"), startDate, endDate)); // date range filtering
+                .where(cb.between(root.get("newDate"), /* date range filtering */startDate, endDate));
 
         return entityManager.createQuery(query).getResultList();
     }


### PR DESCRIPTION
Introduces new query features that allow the client to "capture" a date range in a query by supplying only one date at a time and allowing the API to supply the other dates necessary.

closes #10 

Small optimizations were also made to remove code that violated the DRY design principle.